### PR TITLE
 Update sorbet and sorbet-runtime dependencies to 0.6.0

### DIFF
--- a/guard-sorbet.gemspec
+++ b/guard-sorbet.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'guard', '~> 2.0'
   spec.add_runtime_dependency 'guard-compat', '~> 1.0'
-  spec.add_runtime_dependency 'sorbet', '~> 0.5.0'
-  spec.add_runtime_dependency 'sorbet-runtime', '~> 0.5.0'
+  spec.add_runtime_dependency 'sorbet', '~> 0.6.0'
+  spec.add_runtime_dependency 'sorbet-runtime', '~> 0.6.0'
 end

--- a/guard-sorbet.gemspec
+++ b/guard-sorbet.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'guard', '~> 2.0'
   spec.add_runtime_dependency 'guard-compat', '~> 1.0'
-  spec.add_runtime_dependency 'sorbet', '~> 0.6.0'
-  spec.add_runtime_dependency 'sorbet-runtime', '~> 0.6.0'
+  spec.add_runtime_dependency '>= 0.5.0', '< 0.7.0'
+  spec.add_runtime_dependency 'sorbet-runtime', '>= 0.5.0', '< 0.7.0'
 end


### PR DESCRIPTION
## Description of the change

Updates the gemspec dependencies to require `0.5.0` through `0.6.N`.

## How tested

Tested it with the app.

## Security implications

N/A
