### PR TITLE
 Update sorbet and sorbet-runtime dependencies to 0.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,55 +1,63 @@
 PATH
   remote: .
   specs:
-    guard-sorbet (0.0.1)
+    guard-sorbet (0.6.0)
       guard (~> 2.0)
       guard-compat (~> 1.0)
-      sorbet (~> 0.5.0)
-      sorbet-runtime (~> 0.5.0)
+      sorbet (>= 0.5.0, < 0.7.0)
+      sorbet-runtime (>= 0.5.0, < 0.7.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.1.2)
-    ffi (1.12.2)
-    formatador (0.2.5)
-    guard (2.16.1)
+    coderay (1.1.3)
+    ffi (1.17.2-arm64-darwin)
+    formatador (1.2.1)
+      reline
+    guard (2.19.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
+      logger (~> 1.6)
       lumberjack (>= 1.0.12, < 2.0)
       nenv (~> 0.1)
       notiffany (~> 0.0)
-      pry (>= 0.9.12)
+      ostruct (~> 0.6)
+      pry (>= 0.13.0)
       shellany (~> 0.0)
       thor (>= 0.18.1)
     guard-compat (1.2.1)
-    listen (3.2.1)
+    io-console (0.8.1)
+    listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    lumberjack (1.2.4)
-    method_source (0.9.2)
+    logger (1.7.0)
+    lumberjack (1.4.2)
+    method_source (1.1.0)
     nenv (0.3.0)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.1)
+    ostruct (0.6.3)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
+    reline (0.6.2)
+      io-console (~> 0.5)
     shellany (0.0.1)
-    sorbet (0.5.5345)
-      sorbet-static (= 0.5.5345)
+    sorbet (0.6.12586)
+      sorbet-static (= 0.6.12586)
     sorbet-runtime (0.5.5345)
-    sorbet-static (0.5.5345-universal-darwin-14)
-    thor (1.0.1)
+    sorbet-static (0.6.12586-universal-darwin)
+    thor (1.4.0)
 
 PLATFORMS
-  ruby
+  arm64-darwin-24
 
 DEPENDENCIES
   guard-sorbet!
 
 BUNDLED WITH
-   2.0.2
+   2.7.2

--- a/guard-sorbet.gemspec
+++ b/guard-sorbet.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'guard', '~> 2.0'
   spec.add_runtime_dependency 'guard-compat', '~> 1.0'
-  spec.add_runtime_dependency 'sorbet', '~> 0.5.0'
-  spec.add_runtime_dependency 'sorbet-runtime', '~> 0.5.0'
+  spec.add_runtime_dependency 'sorbet', '~> 0.6.0'
+  spec.add_runtime_dependency 'sorbet-runtime', '~> 0.6.0'
 end

--- a/guard-sorbet.gemspec
+++ b/guard-sorbet.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'guard', '~> 2.0'
   spec.add_runtime_dependency 'guard-compat', '~> 1.0'
-  spec.add_runtime_dependency '>= 0.5.0', '< 0.7.0'
+  spec.add_runtime_dependency 'sorbet', '>= 0.5.0', '< 0.7.0'
   spec.add_runtime_dependency 'sorbet-runtime', '>= 0.5.0', '< 0.7.0'
 end

--- a/guard-sorbet.gemspec
+++ b/guard-sorbet.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'guard-sorbet'
-  spec.version = '0.5.0'
+  spec.version = '0.6.0'
   spec.authors = ['Bradley Buda']
   spec.summary = 'Guard plugin for the Sorbet Ruby type checker'
   spec.license = 'MIT'

--- a/guard-sorbet.gemspec
+++ b/guard-sorbet.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'guard', '~> 2.0'
   spec.add_runtime_dependency 'guard-compat', '~> 1.0'
-  spec.add_runtime_dependency 'sorbet', '~> 0.6.0'
-  spec.add_runtime_dependency 'sorbet-runtime', '~> 0.6.0'
+  spec.add_runtime_dependency '>= 0.5.0', '< 0.7.0'
+  spec.add_runtime_dependency 'sorbet-runtime', '>= 0.5.0', '< 0.7.0'
 end


### PR DESCRIPTION
## Description of the change

Updates the gemspec dependencies to require `0.5.0` through `0.6.N`.

## How tested

Tested it with the app.

## Security implications

N/A
