### PR TITLE
Bump sorbet dependency

### DIFF
--- a/guard-sorbet.gemspec
+++ b/guard-sorbet.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'guard', '~> 2.0'
   spec.add_runtime_dependency 'guard-compat', '~> 1.0'
-  spec.add_runtime_dependency 'sorbet', '~> 0.5.0'
-  spec.add_runtime_dependency 'sorbet-runtime', '~> 0.5.0'
+  spec.add_runtime_dependency 'sorbet', '~> 0.6.0'
+  spec.add_runtime_dependency 'sorbet-runtime', '~> 0.6.0'
 end


### PR DESCRIPTION
Sorbet bumped their version to 0.6 when they dropped support for Ruby 2.7 at the end of August (https://github.com/sorbet/sorbet/pull/9228)

## Description of the change

Just bumped the version specifier

## How tested

I ran this locally against sorbet 0.6.12846 and it still seems to work as normal - on saving a file sorbet reruns against changed files

## Security implications

None